### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/demobusiness1/6c82456c-899c-4543-b31a-7a3801c2728d/8640cbd7-57ab-46a2-975e-1fc97da68aa6/_apis/work/boardbadge/59184a5d-c4e3-4992-b97f-7183ce0e9b2e)](https://dev.azure.com/demobusiness1/6c82456c-899c-4543-b31a-7a3801c2728d/_boards/board/t/8640cbd7-57ab-46a2-975e-1fc97da68aa6/Microsoft.RequirementCategory)
 # ARMpractice
 ARM Templates for reference


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#8](https://dev.azure.com/demobusiness1/6c82456c-899c-4543-b31a-7a3801c2728d/_workitems/edit/8). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.